### PR TITLE
Service Area validation Adjustment

### DIFF
--- a/api/Hmcr.Domain/Hangfire/WorkReportJobService.cs
+++ b/api/Hmcr.Domain/Hangfire/WorkReportJobService.cs
@@ -120,7 +120,6 @@ namespace Hmcr.Domain.Hangfire
             var typedRows = new List<WorkReportTyped>();
             
             if (_statusService.IsFileInProgress(_submission.SubmissionStatusId))
-            //if (_submission.SubmissionStatusId == _statusService.FileInProgress)
             {
                 UpdateSubmissionStatus(_statusService.FileStage3InProgress);
 
@@ -138,16 +137,9 @@ namespace Hmcr.Domain.Hangfire
 
                 CopyCalculatedFieldsFormUntypedRow(typedRows, untypedRows);
                 PerformAdditionalValidation(typedRows);
+                PerformFieldServiceAreaValidation(typedRows);
             }
-            //if (_submission.SubmissionStatusId != _statusService.FileInProgress)
-            if (!_statusService.IsFileInProgress(_submission.SubmissionStatusId))
-            {
-                await CommitAndSendEmailAsync();
-                return true;
-            }
-
-            PerformFieldServiceAreaValidation(typedRows);
-            //if (_submission.SubmissionStatusId != _statusService.FileInProgress)
+            
             if (!_statusService.IsFileInProgress(_submission.SubmissionStatusId))
             {
                 await CommitAndSendEmailAsync();


### PR DESCRIPTION
Service Area validation needs to always occur even if there is a confliction error
This means all stage 2 checks are now performed and this allows the end users to update the file before re-submitting.