### PR TITLE
Hotfix for HMCR-1031

### DIFF
--- a/api/Hmcr.Domain/Hangfire/Base/ReportJobServiceBase.cs
+++ b/api/Hmcr.Domain/Hangfire/Base/ReportJobServiceBase.cs
@@ -187,8 +187,7 @@ namespace Hmcr.Domain.Hangfire.Base
                     submissionRow.WarningDetail = newWarnings.ToString();
                 } else
                 {
-                    //we need to check for 
-                    submissionRow.RowStatusId = _statusService.RowError;
+                    //rows don't need to error when a warning is thrown, it's still a success but with a message.
                     submissionRow.WarningDetail = warnings.GetWarningDetail();
                 }
             }

--- a/api/Hmcr.Domain/Hangfire/WorkReportJobService.cs
+++ b/api/Hmcr.Domain/Hangfire/WorkReportJobService.cs
@@ -340,7 +340,7 @@ namespace Hmcr.Domain.Hangfire
                     if (itemExists)
                     {
                         warnings.AddItem("Reporting Frequency Validation: End Date"
-                            , $"END DATE [{typedRow.EndDate}] should NOT be reported more frequently" +
+                            , $"END DATE [{typedRow.EndDate.Value.ToShortDateString()}] should NOT be reported more frequently" +
                             $" than the Reporting Frequency (days) of [{ typedRow.ActivityCodeValidation.ReportingFrequency}]" +
                             $" for Activity [{ typedRow.ActivityNumber}]. Record conflicts with Record Number(s)" +
                             $"[{String.Join("; ", conflicts.ToArray())}]");
@@ -353,7 +353,7 @@ namespace Hmcr.Domain.Hangfire
                     if (itemExists)
                     {
                         warnings.AddItem("Reporting Frequency Validation: End Date"
-                            , $"END DATE [{typedRow.EndDate}] should NOT be reported more frequently" +
+                            , $"END DATE [{typedRow.EndDate.Value.ToShortDateString()}] should NOT be reported more frequently" +
                             $" than the Reporting Frequency (days) of [{ typedRow.ActivityCodeValidation.ReportingFrequency}]" +
                             $" for Activity [{ typedRow.ActivityNumber}] for Highway Unique [{typedRow.HighwayUnique}]." +
                             $" Record conflicts with Record Number(s) [{String.Join("; ", conflicts.ToArray())}]");
@@ -368,7 +368,7 @@ namespace Hmcr.Domain.Hangfire
                         if (itemExists)
                         { 
                             warnings.AddItem("Reporting Frequency Validation: End Date, GPS position"
-                                , $"END DATE [{typedRow.EndDate}] should NOT be reported more frequently" +
+                                , $"END DATE [{typedRow.EndDate.Value.ToShortDateString()}] should NOT be reported more frequently" +
                                 $" than the Reporting Frequency (days) of [{ typedRow.ActivityCodeValidation.ReportingFrequency}]" +
                                 $" for Activity [{ typedRow.ActivityNumber}]," +
                                 $" Highway Unique [{typedRow.HighwayUnique}]," +
@@ -382,7 +382,7 @@ namespace Hmcr.Domain.Hangfire
                         if (itemExists)
                         {
                             warnings.AddItem("Reporting Frequency Validation: End Date, GPS position"
-                                , $"END DATE [{typedRow.EndDate}] should NOT be reported more frequently" +
+                                , $"END DATE [{typedRow.EndDate.Value.ToShortDateString()}] should NOT be reported more frequently" +
                                 $" than the Reporting Frequency (days) of [{ typedRow.ActivityCodeValidation.ReportingFrequency}]" +
                                 $" for Activity [{ typedRow.ActivityNumber}]," +
                                 $" Highway Unique [{typedRow.HighwayUnique}]," +


### PR DESCRIPTION
reporting frequency checks not finding previous DB entries because they had status of Row Error set on them with warning