### PR TITLE
HMCR-1063

### DIFF
--- a/api/Hmcr.Data/Repositories/RockfallReportRepository.cs
+++ b/api/Hmcr.Data/Repositories/RockfallReportRepository.cs
@@ -27,8 +27,11 @@ namespace Hmcr.Data.Repositories
             {
                 rockfallReport.RockfallReportTyped.SubmissionObjectId = submission.SubmissionObjectId;
 
+                //HMCR-1063 Rockfall reports with same MCRR numbers submitted for different service areas were over writing the original
+                //  changed it from PartyID to ContractTermID which handles the service area and party distinction
                 var entity = await DbSet
-                    .Where(x => x.SubmissionObject.PartyId == submission.PartyId && x.McrrIncidentNumber == rockfallReport.RockfallReportTyped.McrrIncidentNumber)
+                    //.Where(x => x.SubmissionObject.PartyId == submission.PartyId && x.McrrIncidentNumber == rockfallReport.RockfallReportTyped.McrrIncidentNumber)
+                    .Where(x => x.SubmissionObject.ContractTermId == submission.ContractTermId && x.McrrIncidentNumber == rockfallReport.RockfallReportTyped.McrrIncidentNumber)
                     .FirstOrDefaultAsync();
 
                 if (entity == null)

--- a/api/Hmcr.Data/Repositories/WorkReportRepository.cs
+++ b/api/Hmcr.Data/Repositories/WorkReportRepository.cs
@@ -35,8 +35,12 @@ namespace Hmcr.Data.Repositories
             {
                 workReport.WorkReportTyped.SubmissionObjectId = submission.SubmissionObjectId;
 
+                //HMCR-1063 Rockfall reports with same MCRR numbers submitted for different service areas were over writing the original
+                //  Investigation determined that this was also a possible issue for Work Reports
+                //  changed it from PartyID to ContractTermID which handles the service area and party distinction
                 var entity = await DbSet
-                    .Where(x => x.SubmissionObject.PartyId == submission.PartyId && x.RecordNumber == workReport.WorkReportTyped.RecordNumber)
+                    //.Where(x => x.SubmissionObject.PartyId == submission.PartyId && x.RecordNumber == workReport.WorkReportTyped.RecordNumber)
+                    .Where(x => x.SubmissionObject.ContractTermId == submission.ContractTermId && x.RecordNumber == workReport.WorkReportTyped.RecordNumber)
                     .FirstOrDefaultAsync();
 
                 if (entity == null)


### PR DESCRIPTION
changed partyId to ContractTermId in checks for existing record as ContractTerm is distinct amongst party and service area.